### PR TITLE
Add tablet registration feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # tablette_manager
 
-Cette application R Shiny permet de g\u00e9rer l'affectation des tablettes aux agents enqu\u00eateurs, d'enregistrer les retours et de suivre les incidents.
+Cette application R Shiny permet de g\u00e9rer l'affectation des tablettes aux agents enqu\u00eateurs, de les enregistrer en stock, d'enregistrer les retours et de suivre les incidents.
+
+Fonctionnalit\u00e9s principales :
+* Enregistrement des tablettes (manuel ou via un fichier Excel)
+* Affectation individuelle ou en masse des tablettes aux agents
+* Gestion des retours et d\u00e9claration d'incidents
 
 ## Lancer l'application
 


### PR DESCRIPTION
## Summary
- implement registration of tablets individually or in bulk
- prevent assignment of unregistered tablets
- document new workflow and comment code

## Testing
- `Rscript` was not found so app functionality was not tested

------
https://chatgpt.com/codex/tasks/task_e_68637a0c121c8325b97588f6c36a7de9