### PR TITLE
Fix mass operations and reset file inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fonctionnalit\u00e9s principales :
 
 ## Lancer l'application
 
-Assurez-vous d'avoir R et les packages `shiny`, `DT` et `readxl` install\u00e9s, puis ex\u00e9cutez :
+Assurez-vous d'avoir R et les packages `shiny`, `DT`, `readxl` et `shinyjs` install\u00e9s, puis ex\u00e9cutez :
 
 ```R
 shiny::runApp('app.R')


### PR DESCRIPTION
## Summary
- use `shinyjs` to reset file inputs after mass operations
- store mass assignments in the assignments table
- normalize excel inputs as text
- document new dependency

## Testing
- `Rscript` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639edfdc5083258509159180375448