### PR TITLE
Fix docx placeholder replacement

### DIFF
--- a/app.R
+++ b/app.R
@@ -590,6 +590,10 @@ generate_affectation_fiche <- function(assign_data) {
   )
 
   for (v in names(vars)) {
+    # Replace placeholders that may have been split by Word tags
+    name <- gsub("[{}]", "", v)
+    pattern <- paste0("\\{\\{[^\\{\\}]*", name, "[^\\{\\}]*\\}\\}")
+    xml_txt <- gsub(pattern, vars[[v]], xml_txt, perl = TRUE)
     xml_txt <- gsub(v, vars[[v]], xml_txt, fixed = TRUE)
   }
 


### PR DESCRIPTION
## Summary
- handle placeholders that Word splits across XML tags when creating assignment files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d84db4c888325843a50a8bd8ef7a5