### PR TITLE
Add jsQR fallback for QR scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Assurez-vous d'avoir R et les packages `shiny`, `DT`, `readxl` et `shinyjs` inst
 ```R
 shiny::runApp('app.R')
 ```
+
+### QR code
+
+La détection de QR utilise l'API `BarcodeDetector` lorsqu'elle est
+disponible, avec un repli sur la librairie `jsQR` pour les navigateurs
+non compatibles. Assurez‑vous d'accéder à l'application via un contexte
+sécurisé (HTTPS ou `localhost`) afin de permettre l'accès à la caméra.

--- a/app.R
+++ b/app.R
@@ -60,6 +60,7 @@ ui <- navbarPage(
   useShinyjs(),
   tags$head(
     tags$link(rel = "stylesheet", type = "text/css", href = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"),
+    tags$script(src = "https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js"),
     tags$script(src = "qr_scanner.js"),
     tags$style(HTML("
       /* Variables CSS personnalisées */

--- a/www/qr_scanner.js
+++ b/www/qr_scanner.js
@@ -30,6 +30,25 @@ function startQrScanner(targetInput) {
           }).catch(function(){ requestAnimationFrame(detect); });
         };
         requestAnimationFrame(detect);
+      } else if (window.jsQR) {
+        var canvas = document.createElement('canvas');
+        var context = canvas.getContext('2d');
+        var scan = function(){
+          if (!currentStream) return;
+          canvas.width = video.videoWidth;
+          canvas.height = video.videoHeight;
+          context.drawImage(video, 0, 0, canvas.width, canvas.height);
+          var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+          var code = jsQR(imageData.data, canvas.width, canvas.height);
+          if (code) {
+            Shiny.setInputValue(targetInput, code.data, {priority:'event'});
+            stopQrScanner();
+            $("#shiny-modal").modal('hide');
+          } else {
+            requestAnimationFrame(scan);
+          }
+        };
+        requestAnimationFrame(scan);
       } else {
         container.innerHTML = 'BarcodeDetector API non support\xC3\xA9e';
       }


### PR DESCRIPTION
## Summary
- add jsQR as fallback in QR scanner
- load jsQR library in app UI
- document QR scanning requirements in README

## Testing
- `R` was not available so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_686f8c5b7a1483258b26a3366e5fa8cf