### PR TITLE
Fix mobile QR scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,7 @@ shiny::runApp('app.R')
 
 La détection de QR utilise l'API `BarcodeDetector` lorsqu'elle est
 disponible, avec un repli sur la librairie `jsQR` pour les navigateurs
-non compatibles. Assurez‑vous d'accéder à l'application via un contexte
-sécurisé (HTTPS ou `localhost`) afin de permettre l'accès à la caméra.
+non compatibles. **L'accès à la caméra n'est possible que dans un contexte
+sûr** : utilisez impérativement `https` ou `localhost`. Sur mobile,
+une connexion via l'adresse IP en `http` bloquera la demande
+d'autorisation de la caméra.

--- a/www/qr_scanner.js
+++ b/www/qr_scanner.js
@@ -8,50 +8,61 @@ function stopQrScanner() {
 function startQrScanner(targetInput) {
   var container = document.getElementById('qr-reader');
   if (!container) return;
-  container.innerHTML = '<video id="qr-video" playsinline style="width:100%;"></video>';
+  container.innerHTML = '<video id="qr-video" playsinline autoplay muted style="width:100%;"></video>';
   var video = document.getElementById('qr-video');
+
+  if (!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) {
+    container.innerHTML = 'Acc\xC3\xA8s \xC3\xA0 la cam\xC3\xA9ra non disponible. Utilisez HTTPS ou localhost.';
+    return;
+  }
+
   navigator.mediaDevices.getUserMedia({video: {facingMode: 'environment'}})
     .then(function(stream){
       currentStream = stream;
       video.srcObject = stream;
-      video.play();
-      if ('BarcodeDetector' in window) {
-        var detector = new BarcodeDetector({formats:['qr_code']});
-        var detect = function(){
-          if (!currentStream) return;
-          detector.detect(video).then(function(barcodes){
-            if (barcodes.length > 0) {
-              Shiny.setInputValue(targetInput, barcodes[0].rawValue, {priority:'event'});
+      return video.play();
+    })
+    .then(function(){
+      var startDetection = function(){
+        if ('BarcodeDetector' in window) {
+          var detector = new BarcodeDetector({formats:['qr_code']});
+          var detect = function(){
+            if (!currentStream) return;
+            detector.detect(video).then(function(barcodes){
+              if (barcodes.length > 0) {
+                Shiny.setInputValue(targetInput, barcodes[0].rawValue, {priority:'event'});
+                stopQrScanner();
+                $("#shiny-modal").modal('hide');
+              } else {
+                requestAnimationFrame(detect);
+              }
+            }).catch(function(){ requestAnimationFrame(detect); });
+          };
+          requestAnimationFrame(detect);
+        } else if (window.jsQR) {
+          var canvas = document.createElement('canvas');
+          var context = canvas.getContext('2d');
+          var scan = function(){
+            if (!currentStream) return;
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            context.drawImage(video, 0, 0, canvas.width, canvas.height);
+            var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+            var code = jsQR(imageData.data, canvas.width, canvas.height);
+            if (code) {
+              Shiny.setInputValue(targetInput, code.data, {priority:'event'});
               stopQrScanner();
               $("#shiny-modal").modal('hide');
             } else {
-              requestAnimationFrame(detect);
+              requestAnimationFrame(scan);
             }
-          }).catch(function(){ requestAnimationFrame(detect); });
-        };
-        requestAnimationFrame(detect);
-      } else if (window.jsQR) {
-        var canvas = document.createElement('canvas');
-        var context = canvas.getContext('2d');
-        var scan = function(){
-          if (!currentStream) return;
-          canvas.width = video.videoWidth;
-          canvas.height = video.videoHeight;
-          context.drawImage(video, 0, 0, canvas.width, canvas.height);
-          var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-          var code = jsQR(imageData.data, canvas.width, canvas.height);
-          if (code) {
-            Shiny.setInputValue(targetInput, code.data, {priority:'event'});
-            stopQrScanner();
-            $("#shiny-modal").modal('hide');
-          } else {
-            requestAnimationFrame(scan);
-          }
-        };
-        requestAnimationFrame(scan);
-      } else {
-        container.innerHTML = 'BarcodeDetector API non support\xC3\xA9e';
-      }
+          };
+          requestAnimationFrame(scan);
+        } else {
+          container.innerHTML = 'BarcodeDetector API non support\xC3\xA9e';
+        }
+      };
+      startDetection();
     })
     .catch(function(err){
       console.error(err);


### PR DESCRIPTION
## Summary
- ensure the QR scanner waits for camera playback before decoding
- display a clear message when camera access is unavailable
- allow autoplay/muted video for better mobile support
- clarify the README about using HTTPS or localhost for camera access

## Testing
- `Rscript -e "0"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f933cc8e4832588c2438f58823259