### PR TITLE
Fix filter_by_user error when role undefined

### DIFF
--- a/app.R
+++ b/app.R
@@ -710,7 +710,8 @@ server <- function(input, output, session) {
   ))
 
   filter_by_user <- function(data) {
-    if (user_role() == "supervisor") {
+    role <- user_role()
+    if (!is.null(role) && role == "supervisor") {
       data[data$user_login == current_user(), , drop = FALSE]
     } else {
       data


### PR DESCRIPTION
## Summary
- ensure filter_by_user handles NULL `user_role`

## Testing
- `Rscript -e "parse(file='app.R'); cat('Parse OK\n')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fae98253c8325badfe6b810216465