### PR TITLE
Remove supervisor management again

### DIFF
--- a/app.R
+++ b/app.R
@@ -617,18 +617,6 @@ ui <- navbarPage(
         )
       )
     ),
-    fluidRow(
-      column(
-        12,
-        card(
-          card_header("Gestion des superviseurs", class = "card-header"),
-          card_body(
-            fileInput("supervisor_file", "Importer la liste des superviseurs (Excel)", accept = c(".xlsx", ".xls")),
-            DTOutput("supervisors_table")
-          )
-        )
-      )
-    )
   )
 
 # Serveur
@@ -765,27 +753,6 @@ server <- function(input, output, session) {
                   "<p>Vous \u00eates connect\u00e9 en tant qu'administrateur." ,
                   "</p>"))
     }
-  })
-
-  observeEvent(input$supervisor_file, {
-    req(user_role() == "admin", input$supervisor_file)
-    tryCatch({
-      data <- read_excel(input$supervisor_file$datapath)
-      required_cols <- c("user_name", "user_login", "user_password")
-      if (!all(required_cols %in% names(data))) {
-        showNotification("Colonnes manquantes dans le fichier", type = "error")
-      } else {
-        supervisors(data[, required_cols])
-        showNotification("Liste des superviseurs importee", type = "message")
-      }
-    }, error = function(e) {
-      showNotification("Erreur lors de l'import", type = "error")
-    })
-  })
-
-  output$supervisors_table <- renderDT({
-    req(user_role() == "admin")
-    datatable(supervisors(), options = list(pageLength = 10), rownames = FALSE)
   })
 
 


### PR DESCRIPTION
## Summary
- remove the supervisor management section from the Administration tab
- remove server logic that handled supervisor file import

## Testing
- `Rscript -e "source('app.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe5310724832581f5991845165f20