### PR TITLE
Fix Excel import and alert display

### DIFF
--- a/server.R
+++ b/server.R
@@ -3,6 +3,8 @@
 if (!exists("load_supervisors")) source("modules/data_management.R")
 # Protection : charger la logique serveur modulaire si besoin
 if (!exists("register_server_logic")) source("modules/server_modules.R")
+# Charger la génération de fiches si nécessaire
+if (!exists("generate_affectation_fiche")) source("modules/fiche_generation.R")
 # Serveur principal avec toute la logique
 
 server <- function(input, output, session) {


### PR DESCRIPTION
## Summary
- ensure fiche generation module is sourced when server is loaded
- use fully qualified `readxl::read_excel` for bulk registrations and imports
- show scrolling red banner even when there are no alerts

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efaf46ef0832599df268ceab07c01