### PR TITLE
Fix alert UI and navigation layout

### DIFF
--- a/modules/fiche_generation.R
+++ b/modules/fiche_generation.R
@@ -23,12 +23,19 @@ analyze_document_variables <- function(template_path) {
 
 # Fonction principale de génération de fiche
 generate_affectation_fiche <- function(assign_data, template = "Fiche_Affectation_Materiel.docx") {
-  if (!file.exists(template)) {
+  template_paths <- c(
+    template,
+    file.path(getwd(), template),
+    file.path(dirname(getwd()), template),
+    file.path("www", template)
+  )
+  template_path <- template_paths[file.exists(template_paths)][1]
+  if (is.na(template_path)) {
     stop("Template de fiche non trouvé : ", template)
   }
   
   tryCatch({
-    doc <- read_docx(template)
+    doc <- read_docx(template_path)
     
     # Mapping sécurisé des placeholders
     replacements <- list(

--- a/modules/server_modules.R
+++ b/modules/server_modules.R
@@ -1017,6 +1017,6 @@ administration_server_logic <- function(input, output, session, supervisors, reg
     if (is.null(alert_text) || alert_text == "") {
       alert_text <- "Aucune alerte"
     }
-    tags$marquee(span(alert_text, style = "color:red;"))
+    htmltools::tags$marquee(htmltools::span(alert_text, style = "color:red;"))
   })
 }

--- a/ui.R
+++ b/ui.R
@@ -13,12 +13,14 @@ app_ui <- function() {
     id = "navbar",
     title = tagList(icon("tablet-alt"), "Gestion des Tablettes"),
     theme = bs_theme(version = 5, bootswatch = "minty"),
-    useShinyjs(),
-    tags$head(
-      tags$link(rel = "stylesheet", type = "text/css", href = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"),
-      tags$script(src = "https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js"),
-      tags$script(src = "qr_scanner.js"),
-      app_css()
+    header = tagList(
+      useShinyjs(),
+      tags$head(
+        tags$link(rel = "stylesheet", type = "text/css", href = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"),
+        tags$script(src = "https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js"),
+        tags$script(src = "qr_scanner.js"),
+        app_css()
+      )
     ),
     tabPanel(
       "Accueil",


### PR DESCRIPTION
## Summary
- move scripts and stylesheets into navbar header to silence bslib navigation warnings
- make template search more robust for fiche generation
- ensure alert banner uses htmltools explicitly

## Testing
- `R -q -e "cat('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efe3cadc08325ba6f29588b34293b