### PR TITLE
Fix officer print call

### DIFF
--- a/modules/fiche_generation.R
+++ b/modules/fiche_generation.R
@@ -65,7 +65,7 @@ generate_affectation_fiche <- function(assign_data, template = "Fiche_Affectatio
     if (!dir.exists("fiches_generees")) dir.create("fiches_generees")
     filepath <- file.path("fiches_generees", filename)
     
-    officer::print(doc, target = filepath)
+    print(doc, target = filepath)
     return(list(filename = filename, filepath = filepath, data = assign_data))
     
   }, error = function(e) {


### PR DESCRIPTION
## Summary
- call the correct print method when saving generated fiches

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f07d0ad308325873b8021e7119d1b