### PR TITLE
Fix print call

### DIFF
--- a/modules/fiche_generation.R
+++ b/modules/fiche_generation.R
@@ -65,7 +65,9 @@ generate_affectation_fiche <- function(assign_data, template = "Fiche_Affectatio
     if (!dir.exists("fiches_generees")) dir.create("fiches_generees")
     filepath <- file.path("fiches_generees", filename)
     
-    print(doc, target = filepath)
+    # Utiliser explicitement la fonction print de base pour
+    # déclencher la méthode S3 `print.rdocx` fournie par `officer`
+    base::print(doc, target = filepath)
     return(list(filename = filename, filepath = filepath, data = assign_data))
     
   }, error = function(e) {


### PR DESCRIPTION
## Summary
- fix generation of Word file by explicitly using base::print

## Testing
- N/A due to missing R runtime

------
https://chatgpt.com/codex/tasks/task_e_687f09a14f6c8325a4938a8e37e45244