### PR TITLE
Fix path for fiche download link

### DIFF
--- a/modules/server_modules.R
+++ b/modules/server_modules.R
@@ -445,7 +445,7 @@ fiche_server_logic <- function(input, output, session, assignments, generated_fi
     )
 
     download_btn <- sprintf(
-      '<a class="btn btn-sm btn-success" href="fiches/%s" download>Télécharger</a>',
+      '<a class="btn btn-sm btn-success" href="fiches_generees/%s" download>Télécharger</a>',
       fiches$filename
     )
 


### PR DESCRIPTION
## Summary
- correct the link in the fiche history table so downloads reference the proper directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f182003d8832597bade262849263c